### PR TITLE
V0.3.0

### DIFF
--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -5,3 +5,5 @@ export const REQUEST_TIMEOUT = 5000
 export const ETH_CONTRACT = `0x${'0'.repeat(40)}`
 
 export const FEE_RECIPIENT = '0x6f7ae872e995f98fcd2a7d3ba17b7ddfb884305f'
+
+export const ETH_GAS_STATION_URL = 'https://ethgasstation.info/json/ethgasAPI.json'

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,7 +6,7 @@ import { assert as assertUtils } from '0x.js/lib/src/utils/assert'
 import { Server } from './lib/server'
 import Tokenlon from './tokenlon'
 import { toBN } from './utils/math'
-import { lowerCaseObjValue } from './utils/helper'
+import { lowerCaseObj0xValue } from './utils/helper'
 import { assert, rewriteAssertUtils } from './utils/assert'
 import { getGasPriceByAdaptorAsync } from './utils/gasPriceAdaptor'
 import { GlobalConfig, DexOrderBNToString, Tokenlon as TokenlonInterface } from './types'
@@ -14,7 +14,7 @@ import { getPairBySymbol } from './utils/pair'
 import { getSimpleOrderWithBaseQuoteBySignedOrder, getSignedOrder, generateDexOrderWithoutSalt, orderBNToString, orderStringToBN } from './utils/dex'
 
 export const createTokenlon = async (options: GlobalConfig): Promise<Tokenlon> => {
-  const config = lowerCaseObjValue(options)
+  const config = lowerCaseObj0xValue(options)
   // default onChainValidate config is true
   config.onChainValidate = config.onChainValidate === false ? config.onChainValidate : true
   assert.isValidConfig(config)

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,6 +8,7 @@ import Tokenlon from './tokenlon'
 import { toBN } from './utils/math'
 import { lowerCaseObjValue } from './utils/helper'
 import { assert, rewriteAssertUtils } from './utils/assert'
+import { getGasPriceByAdaptorAsync } from './utils/gasPriceAdaptor'
 import { GlobalConfig, DexOrderBNToString, Tokenlon as TokenlonInterface } from './types'
 import { getPairBySymbol } from './utils/pair'
 import { getSimpleOrderWithBaseQuoteBySignedOrder, getSignedOrder, generateDexOrderWithoutSalt, orderBNToString, orderStringToBN } from './utils/dex'
@@ -22,6 +23,7 @@ export const createTokenlon = async (options: GlobalConfig): Promise<Tokenlon> =
   const pairList = await server.getPairList()
   const tokenlon = new Tokenlon()
   const pairs = pairList.filter(p => p.protocol === '0x')
+  const gasPrice = await getGasPriceByAdaptorAsync(config.gasPriceAdaptor)
 
   // need to set privider fitst
   await web3Wrapper.setProvider(new web3Wrapper.providers.HttpProvider(config.web3.providerUrl))
@@ -32,7 +34,7 @@ export const createTokenlon = async (options: GlobalConfig): Promise<Tokenlon> =
   rewriteAssertUtils(assertUtils)
   const zeroExWrapper = createZeroExWrapper({
     ...zeroExConfig,
-    gasPrice: toBN(zeroExConfig.gasPrice),
+    gasPrice: toBN(gasPrice),
   })
 
   return _.extend(tokenlon, {

--- a/src/lib/zeroex-wrapper/_etherToken.ts
+++ b/src/lib/zeroex-wrapper/_etherToken.ts
@@ -23,7 +23,7 @@ export const coverageEtherToken = (obj) => {
       assert.assert(ethBalanceInWei.gte(amountInWei), ZeroExError.InsufficientEthBalanceForDeposit)
 
       const txHash = helper.etherTokenTransaction('deposit', amountInWei, txOpts ? {
-        gas: txOpts.gasLimit,
+        gasLimit: txOpts.gasLimit,
         gasPrice: txOpts.gasPrice,
       } : txOpts)
       return txHash
@@ -48,7 +48,7 @@ export const coverageEtherToken = (obj) => {
       assert.assert(WETHBalanceInBaseUnits.gte(amountInWei), ZeroExError.InsufficientWEthBalanceForWithdrawal)
 
       const txHash = helper.etherTokenTransaction('withdraw', amountInWei, txOpts ? {
-        gas: txOpts.gasLimit,
+        gasLimit: txOpts.gasLimit,
         gasPrice: txOpts.gasPrice,
       } : txOpts)
       return txHash

--- a/src/lib/zeroex-wrapper/_exchange.ts
+++ b/src/lib/zeroex-wrapper/_exchange.ts
@@ -19,7 +19,7 @@ const fillOrderAsync = (
   fillTakerTokenAmount: BigNumber,
   shouldThrowOnInsufficientBalanceOrAllowance: boolean,
   _takerAddress: string,
-  _orderTransactionOpts: OrderTransactionOpts,
+  orderTransactionOpts: OrderTransactionOpts = {},
 ) => {
   const params = signedOrderUtils.createFill(
     signedOrder,
@@ -34,27 +34,27 @@ const fillOrderAsync = (
     params.v,
     params.r,
     params.s,
-  ])
+  ], orderTransactionOpts)
 }
 
 const cancelOrderAsync = (
   signedOrder: SignedOrder,
   cancelTakerTokenAmount: BigNumber,
-  _orderTransactionOpts: OrderTransactionOpts,
+  orderTransactionOpts: OrderTransactionOpts = {},
 ) => {
   const params = signedOrderUtils.createCancel(signedOrder, cancelTakerTokenAmount)
   return helper.exchangeSendTransaction('cancelOrder', [
     params.orderAddresses,
     params.orderValues,
     params.cancelTakerTokenAmount,
-  ])
+  ], orderTransactionOpts)
 }
 
 const fillOrKillOrderAsync = (
   signedOrder: SignedOrder,
   fillTakerTokenAmount: BigNumber,
   _takerAddress: string,
-  _orderTransactionOpts: OrderTransactionOpts,
+  orderTransactionOpts: OrderTransactionOpts = {},
 ) => {
   const shouldThrowOnInsufficientBalanceOrAllowance = true
   const params = signedOrderUtils.createFill(
@@ -69,14 +69,14 @@ const fillOrKillOrderAsync = (
     params.v,
     params.r,
     params.s,
-  ])
+  ], orderTransactionOpts)
 }
 
 const batchFillOrdersAsync = (
   orderFillRequests: OrderFillRequest[],
   shouldThrowOnInsufficientBalanceOrAllowance: boolean,
   _takerAddress: string,
-  _orderTransactionOpts: OrderTransactionOpts,
+  orderTransactionOpts: OrderTransactionOpts = {},
 ) => {
   const params = formatters.createBatchFill(
     orderFillRequests.map(r => r.signedOrder),
@@ -91,13 +91,13 @@ const batchFillOrdersAsync = (
     params.v,
     params.r,
     params.s,
-  ])
+  ], orderTransactionOpts)
 }
 
 const batchFillOrKillAsync = (
   orderFillRequests: OrderFillRequest[],
   _takerAddress: string,
-  _orderTransactionOpts: OrderTransactionOpts = {},
+  orderTransactionOpts: OrderTransactionOpts = {},
 ) => {
   const params = formatters.createBatchFill(
     orderFillRequests.map(r => r.signedOrder),
@@ -111,7 +111,7 @@ const batchFillOrKillAsync = (
     params.v,
     params.r,
     params.s,
-  ])
+  ], orderTransactionOpts)
 }
 
 const fillOrdersUpToAsync = (
@@ -119,7 +119,7 @@ const fillOrdersUpToAsync = (
   fillTakerTokenAmount: BigNumber,
   shouldThrowOnInsufficientBalanceOrAllowance: boolean,
   _takerAddress: string,
-  _orderTransactionOpts: OrderTransactionOpts,
+  orderTransactionOpts: OrderTransactionOpts = {},
 ) => {
   const params = formatters.createFillUpTo(
     signedOrders,
@@ -134,12 +134,12 @@ const fillOrdersUpToAsync = (
     params.v,
     params.r,
     params.s,
-  ])
+  ], orderTransactionOpts)
 }
 
 const batchCancelOrdersAsync = (
   orderCancellationRequests: OrderCancellationRequest[],
-  _orderTransactionOpts: OrderTransactionOpts,
+  orderTransactionOpts: OrderTransactionOpts = {},
 ) => {
   const orders = orderCancellationRequests.map(r => r.order) as SignedOrder[]
   const cancelTakerTokenAmounts = orderCancellationRequests.map(r => r.takerTokenCancelAmount)
@@ -148,7 +148,7 @@ const batchCancelOrdersAsync = (
     params.orderAddresses,
     params.orderValues,
     params.cancelTakerTokenAmounts,
-  ])
+  ], orderTransactionOpts)
 }
 
 export const coverageExchange = (exchange) => {

--- a/src/lib/zeroex-wrapper/_token.ts
+++ b/src/lib/zeroex-wrapper/_token.ts
@@ -12,7 +12,7 @@ export const coverageToken = (obj) => {
   return _.extend(obj, {
     async setAllowanceAsync(
       tokenAddress: string,
-      ownerAddress: string,
+      _ownerAddress: string,
       spenderAddress: string,
       amountInBaseUnits: BigNumber,
       txOpts: TransactionOpts = {},
@@ -23,15 +23,13 @@ export const coverageToken = (obj) => {
       // await assert.isSenderAddressAsync('ownerAddress', ownerAddress, this._web3Wrapper)
       const normalizedTokenAddress = tokenAddress.toLowerCase()
       const normalizedSpenderAddress = spenderAddress.toLowerCase()
-      const normalizedOwnerAddress = ownerAddress.toLowerCase()
       assert.isValidBaseUnitAmount('amountInBaseUnits', amountInBaseUnits)
       return helper.tokenApproveTransaction(
         normalizedTokenAddress,
         normalizedSpenderAddress,
         amountInBaseUnits,
         {
-          from: normalizedOwnerAddress,
-          gas: txOpts.gasLimit,
+          gasLimit: txOpts.gasLimit,
           gasPrice: txOpts.gasPrice,
         },
       )
@@ -62,8 +60,7 @@ export const coverageToken = (obj) => {
         normalizedToAddress,
         amountInBaseUnits,
         {
-          from: normalizedFromAddress,
-          gas: txOpts.gasLimit,
+          gasLimit: txOpts.gasLimit,
           gasPrice: txOpts.gasPrice,
         },
       )
@@ -108,8 +105,7 @@ export const coverageToken = (obj) => {
         normalizedToAddress,
         amountInBaseUnits,
         {
-          from: normalizedSenderAddress,
-          gas: txOpts.gasLimit,
+          gasLimit: txOpts.gasLimit,
           gasPrice: txOpts.gasPrice,
         },
       )

--- a/src/lib/zeroex-wrapper/helper.ts
+++ b/src/lib/zeroex-wrapper/helper.ts
@@ -1,16 +1,19 @@
 import { encodeData, sendTransaction } from '../../utils/ethereum'
 import { BigNumber } from '@0xproject/utils'
 import { GlobalConfig } from '../../types'
+import { getGasPriceByAdaptorAsync } from '../../utils/gasPriceAdaptor'
 
 export default {
   _config: {} as GlobalConfig,
   setConfig(config: GlobalConfig) {
     this._config = config
   },
-  exchangeSendTransaction(method: string, args: any[]) {
-    const { wallet, zeroEx } = this._config
+  async exchangeSendTransaction(method: string, args: any[]) {
+    const { wallet, zeroEx, gasPriceAdaptor } = this._config
     const { address, privateKey } = wallet
-    const { gasLimit, gasPrice, exchangeContractAddress } = zeroEx
+    const { gasLimit, exchangeContractAddress } = zeroEx
+    const gasPrice = await getGasPriceByAdaptorAsync(gasPriceAdaptor)
+
     return sendTransaction({
       address,
       privateKey,
@@ -21,10 +24,11 @@ export default {
       data: encodeData('exchange', method, args),
     })
   },
-  _tokenTransaction(to: string, method: string, args: any[], opts) {
-    const { wallet, zeroEx } = this._config
+  async _tokenTransaction(to: string, method: string, args: any[], opts) {
+    const { wallet, zeroEx, gasPriceAdaptor } = this._config
     const { address, privateKey } = wallet
-    const { gasLimit, gasPrice } = zeroEx
+    const { gasLimit } = zeroEx
+    const gasPrice = await getGasPriceByAdaptorAsync(gasPriceAdaptor)
 
     return sendTransaction({
       address,
@@ -36,10 +40,11 @@ export default {
       data: encodeData('token', method, args),
     })
   },
-  etherTokenTransaction(method: string, amountInBaseUnits: BigNumber, opts) {
-    const { wallet, zeroEx } = this._config
+  async etherTokenTransaction(method: string, amountInBaseUnits: BigNumber, opts) {
+    const { wallet, zeroEx, gasPriceAdaptor } = this._config
     const { address, privateKey } = wallet
-    const { gasLimit, gasPrice, etherTokenContractAddress } = zeroEx
+    const { gasLimit, etherTokenContractAddress } = zeroEx
+    const gasPrice = await getGasPriceByAdaptorAsync(gasPriceAdaptor)
 
     return sendTransaction({
       address,

--- a/src/lib/zeroex-wrapper/helper.ts
+++ b/src/lib/zeroex-wrapper/helper.ts
@@ -10,7 +10,7 @@ export default {
   setConfig(config: GlobalConfig) {
     this._config = config
   },
-  async _getGasLimitAndGasPriceAsync(opts?: TransactionOpts): Promise<Tokenlon.TokenlonTransactionOpts> {
+  async _getGasLimitAndGasPriceAsync(opts?: TransactionOpts): Promise<Tokenlon.TxOpts> {
     const { zeroEx, gasPriceAdaptor } = this._config
     const { gasLimit } = zeroEx
     let gasP = null

--- a/src/types/base.ts
+++ b/src/types/base.ts
@@ -7,6 +7,8 @@ export type Wallet = {
   privateKey: string;
 }
 
+export type GasPriceAdaptor = 'safeLow' | 'average' | 'fast'
+
 export type GlobalConfig = {
   server: {
     url: string;
@@ -16,6 +18,7 @@ export type GlobalConfig = {
   }
   wallet: Wallet
   onChainValidate?: boolean
+  gasPriceAdaptor: GasPriceAdaptor
   zeroEx: {
     gasPrice: number
     gasLimit: number

--- a/src/types/base.ts
+++ b/src/types/base.ts
@@ -20,7 +20,6 @@ export type GlobalConfig = {
   onChainValidate?: boolean
   gasPriceAdaptor: GasPriceAdaptor
   zeroEx: {
-    gasPrice: number
     gasLimit: number
     networkId: number
     exchangeContractAddress: undefined | string

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -31,6 +31,7 @@ export enum TokenlonError {
   InvalidContractMethod = 'INVALID_CONTRACT_METHOD',
   InvalidSideWithOrder = 'INVALID_SIDE_WITH_ORDER',
   InvalidWalletPrivateKey = 'INVALID_WALLET_PRIVATE_KEY',
+  InvalidGasPriceAdaptor = 'INVALID_GAS_PRICE_ADAPTOR',
   EthDoseNotHaveApprovedMethod = 'ETH_DOSE_NOT_HAVE_APPROVED_METHOD',
   InvalidPriceWithToBeFilledOrder = 'INVALID_PRICE_WITH_TO_BE_FILLED_ORDER',
   OrdersMustBeSamePairAndSameSideWithFillOrdersUpTo = 'ORDERS_MUST_BE_SAME_PAIR_AND_SAME_SIDE_WITH_FILLORDERSUPTO',

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -36,7 +36,7 @@ export enum TokenlonError {
   OrdersMustBeSamePairAndSameSideWithFillOrdersUpTo = 'ORDERS_MUST_BE_SAME_PAIR_AND_SAME_SIDE_WITH_FILLORDERSUPTO',
 }
 
-export { Side, Wallet, GlobalConfig, SimpleOrder, DexOrderBNToString } from './base'
+export { GasPriceAdaptor, Side, Wallet, GlobalConfig, SimpleOrder, DexOrderBNToString } from './base'
 export { Dex } from './dex'
 export { Pair } from './pair'
 export { Server } from './server'

--- a/src/types/tokenlon.ts
+++ b/src/types/tokenlon.ts
@@ -77,4 +77,9 @@ export namespace Tokenlon {
     amount: number
     rawOrders: string[]
   }
+
+  export interface TxOpts {
+    gasPrice: number
+    gasLimit: number
+  }
 }

--- a/src/utils/assert.ts
+++ b/src/utils/assert.ts
@@ -69,11 +69,15 @@ export const assert = {
     const addr = ethUtil.privateToAddress(new Buffer(privateKey, 'hex'))
     sharedAssert.assert(helpCompareStr(`0x${addr.toString('hex')}`, address), TokenlonError.InvalidWalletPrivateKey)
   },
+  isValidGasPriceAdaptor(adaptor) {
+    sharedAssert.assert(['safeLow', 'average', 'fast'].includes(adaptor), TokenlonError.InvalidGasPriceAdaptor)
+  },
   isValidConfig(config: GlobalConfig) {
-    const { wallet, web3, server } = config
+    const { wallet, web3, server, gasPriceAdaptor } = config
     sharedAssert.isUri('web3.providerUrl', web3.providerUrl)
     sharedAssert.isUri('server.url', server.url)
     this.isValidWallet(wallet)
+    this.isValidGasPriceAdaptor(gasPriceAdaptor)
   },
 }
 

--- a/src/utils/gasPriceAdaptor.ts
+++ b/src/utils/gasPriceAdaptor.ts
@@ -14,14 +14,30 @@ const getGasPriceByAdaptorHelper = async (adaptor: GasPriceAdaptor): Promise<num
 const stack = {}
 
 export const getGasPriceByAdaptorAsync = async (adaptor: GasPriceAdaptor): Promise<number> => {
-  if (stack[adaptor] && stack[adaptor].timestamp < getTimestamp() + 60) {
+  // Use variable cache data within 5mins
+  if (stack[adaptor] && stack[adaptor].timestamp + 300 > getTimestamp()) {
     return stack[adaptor].gasPrice
+  } else if (stack[adaptor] && stack[adaptor].requesting) {
+
+    // only try to recursive call 15 times
+    if (stack[adaptor].tried > 15) {
+      newError(`${ETH_GAS_STATION_URL} server request timeout`)
+
+    } else {
+      await new Promise((resolve) => {
+        setTimeout(resolve, 1000)
+      })
+      stack[adaptor].tried = stack[adaptor].tried ? stack[adaptor].tried + 1 : 1
+      return getGasPriceByAdaptorAsync(adaptor)
+    }
   } else {
+    stack[adaptor] = { requesting: true }
     const gasPrice = await getGasPriceByAdaptorHelper(adaptor)
     const gasPriceInGwei = gasPrice * Math.pow(10, 9) // gwei process
     stack[adaptor] = {
       gasPrice: gasPriceInGwei,
       timestamp: getTimestamp(),
+      requesting: false,
     }
     return gasPriceInGwei
   }

--- a/src/utils/gasPriceAdaptor.ts
+++ b/src/utils/gasPriceAdaptor.ts
@@ -18,10 +18,11 @@ export const getGasPriceByAdaptorAsync = async (adaptor: GasPriceAdaptor): Promi
     return stack[adaptor].gasPrice
   } else {
     const gasPrice = await getGasPriceByAdaptorHelper(adaptor)
+    const gasPriceInGwei = gasPrice * Math.pow(10, 9) // gwei process
     stack[adaptor] = {
-      gasPrice: gasPrice * Math.pow(10, 9), // gwei process
+      gasPrice: gasPriceInGwei,
       timestamp: getTimestamp(),
     }
-    return gasPrice * Math.pow(10, 9)
+    return gasPriceInGwei
   }
 }

--- a/src/utils/gasPriceAdaptor.ts
+++ b/src/utils/gasPriceAdaptor.ts
@@ -19,9 +19,9 @@ export const getGasPriceByAdaptorAsync = async (adaptor: GasPriceAdaptor): Promi
   } else {
     const gasPrice = await getGasPriceByAdaptorHelper(adaptor)
     stack[adaptor] = {
-      gasPrice: gasPrice * 100000000, // gwei process
+      gasPrice: gasPrice * Math.pow(10, 9), // gwei process
       timestamp: getTimestamp(),
     }
-    return gasPrice * 100000000
+    return gasPrice * Math.pow(10, 9)
   }
 }

--- a/src/utils/gasPriceAdaptor.ts
+++ b/src/utils/gasPriceAdaptor.ts
@@ -1,0 +1,27 @@
+import { GasPriceAdaptor } from '../types'
+import axios from 'axios'
+import { ETH_GAS_STATION_URL } from '../constants'
+import { getTimestamp, newError } from './helper'
+
+export const getGasPriceByAdaptorHelper = async (adaptor: GasPriceAdaptor): Promise<number> => {
+  return axios(ETH_GAS_STATION_URL).then(res => {
+    return res.data[adaptor] * 0.1
+  }).catch(e => {
+    throw newError(`${ETH_GAS_STATION_URL} server error ${e && e.message}`)
+  })
+}
+
+const stack = {}
+
+export const getGasPriceByAdaptorAsync = async (adaptor: GasPriceAdaptor): Promise<number> => {
+  if (stack[adaptor] && stack[adaptor].timestamp < getTimestamp() + 60) {
+    return stack[adaptor].gasPrice
+  } else {
+    const gasPrice = await getGasPriceByAdaptorHelper(adaptor)
+    stack[adaptor] = {
+      gasPrice: gasPrice * 100000000, // gwei process
+      timestamp: getTimestamp(),
+    }
+    return gasPrice * 100000000
+  }
+}

--- a/src/utils/gasPriceAdaptor.ts
+++ b/src/utils/gasPriceAdaptor.ts
@@ -3,7 +3,7 @@ import axios from 'axios'
 import { ETH_GAS_STATION_URL } from '../constants'
 import { getTimestamp, newError } from './helper'
 
-export const getGasPriceByAdaptorHelper = async (adaptor: GasPriceAdaptor): Promise<number> => {
+const getGasPriceByAdaptorHelper = async (adaptor: GasPriceAdaptor): Promise<number> => {
   return axios(ETH_GAS_STATION_URL).then(res => {
     return res.data[adaptor] * 0.1
   }).catch(e => {

--- a/src/utils/helper.ts
+++ b/src/utils/helper.ts
@@ -1,4 +1,7 @@
 import * as _ from 'lodash'
+import { toBN } from './math'
+import { Tokenlon } from '../types'
+import { TransactionOpts } from '0x.js'
 
 export const newError = (msg: string): Error => new Error(msg)
 
@@ -48,4 +51,12 @@ export const leftPadWith0 = (str, len) => {
   len = len - str.length
   if (len <= 0) return str
   return '0'.repeat(len) + str
+}
+
+export const convertTokenlonTxOptsTo0xOpts = (opts: Tokenlon.TxOpts): TransactionOpts => {
+  const { gasLimit, gasPrice } = opts
+  return {
+    gasLimit,
+    gasPrice: toBN(gasPrice),
+  }
 }

--- a/src/utils/helper.ts
+++ b/src/utils/helper.ts
@@ -22,7 +22,7 @@ export const convertTrades = (trades => {
 })
 
 // Only support object
-export const lowerCaseObjValue = (obj: any): any => {
+export const lowerCaseObj0xValue = (obj: any): any => {
   const keys = _.keys(obj)
   const conf = {}
 
@@ -30,9 +30,9 @@ export const lowerCaseObjValue = (obj: any): any => {
     const v = obj[k]
 
     if (_.isPlainObject(v)) {
-      conf[k] = lowerCaseObjValue(v)
+      conf[k] = lowerCaseObj0xValue(v)
 
-    } else if (_.isString(v)) {
+    } else if (_.isString(v) && v.toLowerCase().startsWith('0x')) {
       conf[k] = v.toLowerCase()
 
     } else {

--- a/src/utils/helper.ts
+++ b/src/utils/helper.ts
@@ -54,9 +54,12 @@ export const leftPadWith0 = (str, len) => {
 }
 
 export const convertTokenlonTxOptsTo0xOpts = (opts: Tokenlon.TxOpts): TransactionOpts => {
-  const { gasLimit, gasPrice } = opts
-  return {
-    gasLimit,
-    gasPrice: toBN(gasPrice),
+  if (opts) {
+    const { gasLimit, gasPrice } = opts
+    return {
+      gasLimit,
+      gasPrice: gasPrice ? toBN(gasPrice) : gasPrice,
+    } as TransactionOpts
   }
+  return opts as any
 }

--- a/tests/__mock__/config.ts
+++ b/tests/__mock__/config.ts
@@ -1,3 +1,5 @@
+import { GasPriceAdaptor } from '../../src/types'
+
 export const wallet = {
   address: '0x20F0C6e79A763E1Fe83DE1Fbf08279Aa3953FB5f',
   privateKey: '3f992df8720a778e68a82d27a47d91155ce69ea9954b46ef85afaf19c75bd192',
@@ -34,6 +36,7 @@ export const localConfig = {
     providerUrl: web3ProviderUrl,
   },
   zeroEx: zeroExConfig,
+  gasPriceAdaptor: 'safeLow' as GasPriceAdaptor,
 }
 
 export const localConfigUseToFill = {
@@ -45,4 +48,5 @@ export const localConfigUseToFill = {
     providerUrl: web3ProviderUrl,
   },
   zeroEx: zeroExConfig,
+  gasPriceAdaptor: 'safeLow' as GasPriceAdaptor,
 }

--- a/tests/__mock__/config.ts
+++ b/tests/__mock__/config.ts
@@ -21,7 +21,6 @@ export const web3ProviderUrl = 'https://kovan.infura.io'
 export const zeroExConfig = {
   networkId: 42,
   gasLimit: 150000,
-  gasPrice: 20000000000,
   etherTokenContractAddress: '0xd0a1e359811322d97991e03f863a0c30c2cf029c',
   exchangeContractAddress: '0x90fe2af704b34e0224bf2299c838e04d4dcf1364',
   tokenTransferProxyContractAddress: '0x087Eed4Bc1ee3DE49BeFbd66C662B434B15d49d4',

--- a/tests/__mock__/config.ts
+++ b/tests/__mock__/config.ts
@@ -35,7 +35,7 @@ export const localConfig = {
     providerUrl: web3ProviderUrl,
   },
   zeroEx: zeroExConfig,
-  gasPriceAdaptor: 'safeLow' as GasPriceAdaptor,
+  gasPriceAdaptor: 'average' as GasPriceAdaptor,
 }
 
 export const localConfigUseToFill = {

--- a/tests/tokenlon/fillOrder.test.ts
+++ b/tests/tokenlon/fillOrder.test.ts
@@ -33,6 +33,7 @@ describe('test fillOrder / batchFillOrders / fillOrKillOrder / batchfillOrKill',
         bids: filterOrderBook(orderBook.bids),
       }
 
+      // small amount
       for (let side of ['BUY', 'SELL']) {
         const baseTokenBalance1 = await tokenlon.getTokenBalance(sntWethPairData.base.symbol)
         const quoteTokenBalance1 = await tokenlon.getTokenBalance(sntWethPairData.quote.symbol)
@@ -53,10 +54,11 @@ describe('test fillOrder / batchFillOrders / fillOrKillOrder / batchfillOrKill',
         await waitMined(txHash, 60)
         const baseTokenBalance2 = await tokenlon.getTokenBalance(sntWethPairData.base.symbol)
         const quoteTokenBalance2 = await tokenlon.getTokenBalance(sntWethPairData.quote.symbol)
-        expect(toBN(baseTokenBalance1)[isBuy ? 'plus' : 'minus'](toBN(baseAmount)).toString()).toEqual(toBN(baseTokenBalance2).toString())
-        expect(toBN(quoteTokenBalance1)[isBuy ? 'minus' : 'plus'](toBN(baseAmount).times(toBN(simpleOrder.price))).toFixed(12)).toEqual(toBN(quoteTokenBalance2).toFixed(12))
+        expect(toBN(baseTokenBalance1)[isBuy ? 'plus' : 'minus'](toBN(baseAmount)).toFixed(10)).toEqual(toBN(baseTokenBalance2).toFixed(10))
+        expect(toBN(quoteTokenBalance1)[isBuy ? 'minus' : 'plus'](toBN(baseAmount).times(toBN(simpleOrder.price))).toFixed(10)).toEqual(toBN(quoteTokenBalance2).toFixed(10))
       }
 
+      // large amount
       for (let side of ['BUY', 'SELL']) {
         const baseTokenBalance3 = await tokenlon.getTokenBalance(sntWethPairData.base.symbol)
         const quoteTokenBalance3 = await tokenlon.getTokenBalance(sntWethPairData.quote.symbol)
@@ -91,8 +93,8 @@ describe('test fillOrder / batchFillOrders / fillOrKillOrder / batchfillOrKill',
           await waitMined(txHash, 60)
           const baseTokenBalance4 = await tokenlon.getTokenBalance(sntWethPairData.base.symbol)
           const quoteTokenBalance4 = await tokenlon.getTokenBalance(sntWethPairData.quote.symbol)
-          expect(toBN(baseTokenBalance3)[isBuy ? 'plus' : 'minus'](toBN(simpleOrder.amount)).toString()).toEqual(toBN(baseTokenBalance4).toString())
-          expect(toBN(quoteTokenBalance3)[isBuy ? 'minus' : 'plus'](toBN(simpleOrder.amount).times(toBN(simpleOrder.price))).toFixed(12)).toEqual(toBN(quoteTokenBalance4).toFixed(12))
+          expect(toBN(baseTokenBalance3)[isBuy ? 'plus' : 'minus'](toBN(simpleOrder.amount)).toFixed(10)).toEqual(toBN(baseTokenBalance4).toFixed(10))
+          expect(toBN(quoteTokenBalance3)[isBuy ? 'minus' : 'plus'](toBN(simpleOrder.amount).times(toBN(simpleOrder.price))).toFixed(10)).toEqual(toBN(quoteTokenBalance4).toFixed(10))
         }
       }
 
@@ -124,8 +126,8 @@ describe('test fillOrder / batchFillOrders / fillOrKillOrder / batchfillOrKill',
       const baseTokenBalance6 = await tokenlon.getTokenBalance(sntWethPairData.base.symbol)
       const quoteTokenBalance6 = await tokenlon.getTokenBalance(sntWethPairData.quote.symbol)
 
-      expect(toBN(baseTokenBalance5).toString()).toEqual(toBN(baseTokenBalance6).toString())
-      expect(toBN(quoteTokenBalance5).toFixed(12)).toEqual(toBN(quoteTokenBalance6).toFixed(12))
+      expect(toBN(baseTokenBalance5).toFixed(10)).toEqual(toBN(baseTokenBalance6).toFixed(10))
+      expect(toBN(quoteTokenBalance5).toFixed(10)).toEqual(toBN(quoteTokenBalance6).toFixed(10))
     }
   })
 })

--- a/tests/tokenlon/trades.test.ts
+++ b/tests/tokenlon/trades.test.ts
@@ -12,7 +12,7 @@ import { simpleOrders } from '../__mock__/simpleOrder'
 import { waitSeconds, waitMined } from '../__utils__/wait'
 import { getTimestamp } from '../../src/utils/helper'
 
-jasmine.DEFAULT_TIMEOUT_INTERVAL = 120000
+jasmine.DEFAULT_TIMEOUT_INTERVAL = 200000
 
 let tokenlon = null as Tokenlon
 web3.setProvider(new Web3.providers.HttpProvider(web3ProviderUrl))

--- a/tests/utils/assert.test.ts
+++ b/tests/utils/assert.test.ts
@@ -157,6 +157,23 @@ describe('our assert utils', () => {
       })
     })
 
+    describe('assert.isValidGasPriceAdaptor', () => {
+      const arr = ['safeLow', 'average', 'fast']
+      arr.forEach(item => {
+          it(`${item} is valid`, () => {
+            expect(assert.isValidGasPriceAdaptor(item)).toBeUndefined()
+          })
+        })
+
+      arr.map(x => ' ' + x).forEach(item => {
+        it(`${item} is invalid`, () => {
+          expect(() => {
+            assert.isValidGasPriceAdaptor(item)
+          }).toThrow()
+        })
+      })
+    })
+
     describe('assert.isValidWallet', () => {
       it('wallet is valid', () => {
         expect(assert.isValidWallet(wallet)).toBeUndefined()

--- a/tests/utils/gasPriceAdaptor.test.ts
+++ b/tests/utils/gasPriceAdaptor.test.ts
@@ -1,6 +1,7 @@
 import { GasPriceAdaptor } from '../../src/types'
 import { getGasPriceByAdaptorAsync } from '../../src/utils/gasPriceAdaptor'
 import { waitSeconds } from '../__utils__/wait'
+import * as _ from 'lodash'
 
 jasmine.DEFAULT_TIMEOUT_INTERVAL = 120000
 
@@ -13,9 +14,9 @@ describe('test adaptor', () => {
       expect(gasPriceBefore).toBeGreaterThanOrEqual(Math.pow(10, 9))
     })
 
-    it(`${ad} within 30 seconds should be same`, async () => {
+    it(`${ad} within 60 seconds should be same`, async () => {
       const gasPriceBefore = await getGasPriceByAdaptorAsync(ad as GasPriceAdaptor)
-      await waitSeconds(25)
+      await waitSeconds(40)
       const gasPrice25 = await getGasPriceByAdaptorAsync(ad as GasPriceAdaptor)
       expect(gasPriceBefore).toEqual(gasPrice25)
     })

--- a/tests/utils/gasPriceAdaptor.test.ts
+++ b/tests/utils/gasPriceAdaptor.test.ts
@@ -10,7 +10,7 @@ describe('test adaptor', () => {
   for (let ad of testData) {
     it(`${ad} should larger than or equal with 1Gwei`, async () => {
       const gasPriceBefore = await getGasPriceByAdaptorAsync(ad as GasPriceAdaptor)
-      expect(gasPriceBefore).toBeGreaterThanOrEqual(100000000)
+      expect(gasPriceBefore).toBeGreaterThanOrEqual(Math.pow(10, 9))
     })
 
     it(`${ad} within 30 seconds should be same`, async () => {

--- a/tests/utils/gasPriceAdaptor.test.ts
+++ b/tests/utils/gasPriceAdaptor.test.ts
@@ -1,0 +1,32 @@
+import { GasPriceAdaptor } from '../../src/types'
+import { getGasPriceByAdaptorAsync } from '../../src/utils/gasPriceAdaptor'
+import { waitSeconds } from '../__utils__/wait'
+
+jasmine.DEFAULT_TIMEOUT_INTERVAL = 120000
+
+const testData = ['safeLow', 'average', 'fast']
+
+describe('test adaptor', () => {
+  for (let ad of testData) {
+    it(`${ad} should larger than or equal with 1Gwei`, async () => {
+      const gasPriceBefore = await getGasPriceByAdaptorAsync(ad as GasPriceAdaptor)
+      expect(gasPriceBefore).toBeGreaterThanOrEqual(100000000)
+    })
+
+    it(`${ad} within 30 seconds should be same`, async () => {
+      const gasPriceBefore = await getGasPriceByAdaptorAsync(ad as GasPriceAdaptor)
+      await waitSeconds(25)
+      const gasPrice25 = await getGasPriceByAdaptorAsync(ad as GasPriceAdaptor)
+      expect(gasPriceBefore).toEqual(gasPrice25)
+    })
+  }
+
+  it(`fast should larger than average, and average should larger then safeLow`, async () => {
+    const gasPriceA = await getGasPriceByAdaptorAsync('fast')
+    const gasPriceB = await getGasPriceByAdaptorAsync('average')
+    const gasPriceC = await getGasPriceByAdaptorAsync('safeLow')
+
+    expect(gasPriceA).toBeGreaterThan(gasPriceB)
+    expect(gasPriceB).toBeGreaterThan(gasPriceC)
+  })
+})

--- a/tests/utils/gasPriceAdaptor.test.ts
+++ b/tests/utils/gasPriceAdaptor.test.ts
@@ -27,7 +27,7 @@ describe('test adaptor', () => {
     const gasPriceB = await getGasPriceByAdaptorAsync('average')
     const gasPriceC = await getGasPriceByAdaptorAsync('safeLow')
 
-    expect(gasPriceA).toBeGreaterThan(gasPriceB)
-    expect(gasPriceB).toBeGreaterThan(gasPriceC)
+    expect(gasPriceA).toBeGreaterThanOrEqual(gasPriceB)
+    expect(gasPriceB).toBeGreaterThanOrEqual(gasPriceC)
   })
 })

--- a/tests/utils/helper.test.ts
+++ b/tests/utils/helper.test.ts
@@ -1,5 +1,5 @@
 import * as _ from 'lodash'
-import { newError, lowerCase, getTimestamp, helpCompareStr, lowerCaseObjValue, leftPadWith0 } from '../../src/utils/helper'
+import { newError, lowerCase, getTimestamp, helpCompareStr, lowerCaseObj0xValue, leftPadWith0 } from '../../src/utils/helper'
 
 describe('newError', () => {
   const msg = 'foo'
@@ -34,7 +34,23 @@ describe('helpCompareStr', () => {
   })
 })
 
-describe('lowerCaseObjValue', () => {
+describe('lowerCaseObj0xValue - 0x string', () => {
+  const x = {
+    a: {
+      b: {
+        c: {
+          d: '0X',
+        },
+      },
+    },
+  }
+  const xTobeLowerCase = lowerCaseObj0xValue(x)
+  it('lowerCaseObj0xValue', () => {
+    expect(x.a.b.c.d.toLowerCase()).toBe(xTobeLowerCase.a.b.c.d)
+  })
+})
+
+describe('lowerCaseObj0xValue - not 0x string', () => {
   const x = {
     a: {
       b: {
@@ -44,9 +60,10 @@ describe('lowerCaseObjValue', () => {
       },
     },
   }
-  const xTobeLowerCase = lowerCaseObjValue(x)
-  it('lowerCaseObjValue', () => {
-    expect(x.a.b.c.d.toLowerCase()).toBe(xTobeLowerCase.a.b.c.d)
+  const converted = lowerCaseObj0xValue(x)
+  it('lowerCaseObj0xValue', () => {
+    expect(x.a.b.c.d).toBe(converted.a.b.c.d)
+    expect(x.a.b.c.d.toLowerCase()).toBe(converted.a.b.c.d.toLowerCase())
   })
 })
 


### PR DESCRIPTION
1. `Global Config` 中添加 `gasPriceAdaptor` 配置，支持3个选项：`safeLow`、`average`、`fast`，使用使 `https://ethgasstation.info/json/ethgasAPI.json` 中相应字段作为gasPrice，并且每1分钟内，相同选项获取到的gasPrice 使用的是缓存的数据
2. 取消 `zeroexConfig` 中的 `gasPrice` 配置
3. 更改 `lowerCaseObjValue` 实现，只将 global config 中 `0x` 开头的字符串做小写处理，避免对`safeLow` 小写造成的影响
4. tokenlon相应上链发送交易的方法，添加额外的 `opts` 参数，如存在这部分参数，则不再通过 gasPriceAdaptor 发送请求获取 gasPrice，而使用开发者配置的参数。`gasLimit` 同理
```
tokenlon.deposit
tokenlon.withdraw
tokenlon.setAllowance
tokenlon.setUnlimitedAllowance
tokenlon.fillOrder
tokenlon.fillOrKillOrder
tokenlon.batchFillOrders
tokenlon.batchFillOrKill
tokenlon.fillOrdersUpTo
tokenlon.cancelOrder
tokenlon.batchCancelOrders
```
5. 支持 0x 覆盖的相关上链发送交易方法对应 `opts` (即`gasLimit`、`gasPrice`) 的参数传递（原已支持）与处理（原不支持）

```
tokenlon.zeroExWrapper.token.setAllowanceAsync
tokenlon.zeroExWrapper.token.transferAsync
tokenlon.zeroExWrapper.token.transferFromAsync
tokenlon.zeroExWrapper.token.setUnlimitedAllowanceAsync
tokenlon.zeroExWrapper.token.setProxyAllowanceAsync
tokenlon.zeroExWrapper.token.setUnlimitedProxyAllowanceAsync

tokenlon.zeroExWrapper.etherToken.depositAsync
tokenlon.zeroExWrapper.etherToken.withdrawAsync

tokenlon.zeroExWrapper.exchange.fillOrderAsync
tokenlon.zeroExWrapper.exchange.cancelOrderAsync
tokenlon.zeroExWrapper.exchange.fillOrKillOrderAsync
tokenlon.zeroExWrapper.exchange.batchFillOrdersAsync
tokenlon.zeroExWrapper.exchange.batchFillOrKillAsync
tokenlon.zeroExWrapper.exchange.fillOrdersUpToAsync
tokenlon.zeroExWrapper.exchange.batchCancelOrdersAsync
```