### PR TITLE
V0.3.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,6 @@
     "0x.js": "^0.33.0",
     "@0xproject/utils": "^0.4.0",
     "axios": "^0.18.0",
-    "bignumber.js": "^6.0.0",
     "ethereumjs-abi": "^0.6.5",
     "ethereumjs-tx": "^1.3.3",
     "ethereumjs-util": "^5.1.5",

--- a/src/tokenlon.ts
+++ b/src/tokenlon.ts
@@ -153,7 +153,7 @@ export default class Tokenlon {
       price: params.price,
       amount: params.amount,
       amountTotal: params.amount,
-      expirationUnixTimestampSec: params.expirationUnixTimestampSec,
+      expirationUnixTimestampSec: params.expirationUnixTimestampSec || +toBePlacedOrder.expirationUnixTimestampSec,
       // for key sequence to be same with server order rawOrder
       rawOrder: JSON.stringify({
         exchangeContractAddress: toBePlacedOrder.exchangeContractAddress,

--- a/tests/tokenlon/jwt.test.ts
+++ b/tests/tokenlon/jwt.test.ts
@@ -9,6 +9,8 @@ import { jsonrpc } from '../../src/lib/server/_request'
 import { personalSign } from '../../src/utils/sign'
 import { getTimestamp } from '../../src/utils/helper'
 
+jasmine.DEFAULT_TIMEOUT_INTERVAL = 120000
+
 const server = new Server(localConfig.server.url, localConfig.wallet)
 
 const getToken = async (timestamp, wallet: Wallet) => {
@@ -68,7 +70,7 @@ describe('test getToken', () => {
     },
     {
       testMsg: 'should faild when getting token failed with timestamp more then 1 hour after',
-      timestamp: getTimestamp() + 3601,
+      timestamp: getTimestamp() + 3660,
       wallet: localConfig.wallet,
       errorMsg: 'timestamp',
       result: false,


### PR DESCRIPTION
1. 修复 每个请求都会进行getToken 的问题 （造成后端请求过多，影响接口返回效率）
2. 修复 `tokenlon.placeOrder` 在未传递 `expirationUnixTimestampSec` 情况下，返回结果 order 与 `tokenlon.getOrderBook` 返回结果 orders 中的 order 不一致的问题
3. 移除 未使用的bignumber.js package 依赖 （使用的bignumber 是从 @0xproject/utils 引入的）https://github.com/consenlabs/tokenlon-sdk/issues/5